### PR TITLE
Feature/dv 111 mongo local

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -37,5 +37,8 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 .env 
+.env.test
 .env.production
 .env.yaml 
+
+/db_backup

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  database:
+    container_name: mongodb_dataviewer
+    image: mongo
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: 12345678
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_vol_dataviewer:/data/db
+
+volumes:
+  mongodb_vol_dataviewer: 

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "dotenv -e .env.test -- jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs-modules/mailer": "^1.8.1",
@@ -55,6 +55,7 @@
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
+    "dotenv-cli": "^7.4.3",
     "eslint": "^8.0.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
@@ -75,7 +76,7 @@
       "json",
       "ts"
     ],
-    "rootDir": ".",
+    "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
@@ -84,6 +85,10 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/"
+    ]
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -16,7 +16,7 @@ import { QuestionsModule } from './modules/questions/questions.module';
     ConfigModule.forRoot(),
     MongooseModule.forRoot(process.env.DATABASE_HOST, {
       authMechanism: 'DEFAULT',
-      dbName: 'dataviewert1',
+      dbName: process.env.DATABASE_NAME,
     }),
     UsersModule,
     AuthModule,

--- a/backend/src/modules/questions/questions.controller.ts
+++ b/backend/src/modules/questions/questions.controller.ts
@@ -7,16 +7,19 @@ import { DifficultyOfQuestionDto } from './dto/post-difficulty-of-question';
 export class QuestionsController {
   constructor(private questionsService: QuestionsService) {}
 
+  @UseGuards(JwtAuthGuard)
   @Get('difficulty/:id')
   findDifficultyQuestionById(@Param('id') id: string) {
     return this.questionsService.findDifficultyQuestionById(id);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Post('difficulty')
   createDifficultyForQuestion(@Body() request: DifficultyOfQuestionDto) {
     return this.questionsService.createDifficultyOfQuestion(request);
   }
 
+  @UseGuards(JwtAuthGuard)
   @Put('difficulty/:id')
   updateDifficultyForQuestion(@Param('id') id: string, @Body() request: DifficultyOfQuestionDto) {
     return this.questionsService.updateDifficultyOfQuestion(id, request);

--- a/backend/src/modules/questions/questions.repository.ts
+++ b/backend/src/modules/questions/questions.repository.ts
@@ -11,7 +11,7 @@ export class QuestionsRepository {
     private readonly questionsByDifficultyModel: Model<QuestionsByDifficultyDocument>
   ) {}
 
-  async findById(questionId: string): Promise<QuestionsByDifficulty | null> {
+  async findById(questionId: string): Promise<QuestionsByDifficulty> {
     return await this.questionsByDifficultyModel
       .findOne({ question_id: questionId })
       .exec();
@@ -22,7 +22,7 @@ export class QuestionsRepository {
     return await newQuestion.save();
   }
 
-  async updateById(id: string, updateData: Partial<DifficultyOfQuestionDto>): Promise<QuestionsByDifficulty | null> {
+  async updateById(id: string, updateData: Partial<DifficultyOfQuestionDto>): Promise<QuestionsByDifficulty> {
     return await this.questionsByDifficultyModel
       .findOneAndUpdate(
         { question_id: id },

--- a/backend/src/modules/questions/test/e2e/questions.controller.e2e-spec.ts
+++ b/backend/src/modules/questions/test/e2e/questions.controller.e2e-spec.ts
@@ -2,10 +2,16 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from '../../../../app.module';
+import { Connection } from 'mongoose';
+import { User } from 'src/modules/users/schemas/user.schema';
+import { JwtService } from '@nestjs/jwt';
+import { UsersService } from 'src/modules/users/users.service';
 
 describe('QuestionsController (E2E)', () => {
   let app: INestApplication;
   let questionId: string;
+  let dbConnection: Connection;
+  let authToken: string;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -14,22 +20,40 @@ describe('QuestionsController (E2E)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
+    
+    const userService = app.get(UsersService);
+    const user = await userService.create({
+      name: 'João',
+      email: 'teste@gmail.com',
+      password: '123',
+      avatar: 'default.png',
+      registrationNumber: '10',
+    });
+    
+    const jwtService = app.get(JwtService);
+    authToken = jwtService.sign({ sub: user.id, username: user.name });
+
+    dbConnection = app.get<Connection>('DatabaseConnection');
 
     // Seed de questão
     const createResponse = await request(app.getHttpServer())
       .post(`/questions/difficulty`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send({ question_id: '1000', percentage: 30 });
 
     questionId = createResponse.body.question_id;
   });
 
   afterAll(async () => {
+    await dbConnection.db.dropDatabase();
+    await dbConnection.close();
     await app.close();
   });
 
   it('/questions/difficulty/:id (GET) should return question by difficulty', async () => {
     const response = await request(app.getHttpServer())
       .get(`/questions/difficulty/${questionId}`)
+      .set('Authorization', `Bearer ${authToken}`)
       .expect(200);
 
     expect(response.body).toHaveProperty('question_id', questionId);
@@ -41,6 +65,7 @@ describe('QuestionsController (E2E)', () => {
 
     const response = await request(app.getHttpServer())
       .post(`/questions/difficulty`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send(requestDto)
       .expect(201);
 
@@ -54,6 +79,7 @@ describe('QuestionsController (E2E)', () => {
 
     const response = await request(app.getHttpServer())
       .put(`/questions/difficulty/${questionId}`)
+      .set('Authorization', `Bearer ${authToken}`)
       .send(requestDto)
       .expect(200);
 

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/$1"
   }
 }

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -3199,7 +3199,17 @@ domutils@^3.0.1:
     domelementtype "^2.3.0"
     domhandler "^5.0.3"
 
-dotenv-expand@10.0.0:
+dotenv-cli@^7.4.3:
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/dotenv-cli/-/dotenv-cli-7.4.3.tgz#3f54cbf57d463896cf82e391a5c1598bf92ac9fd"
+  integrity sha512-lf1E+TL1xFeoOHy2hSO3kLkx3KX8CDi17ccn5z5dVCnk2PuWqUKAnBVgQmhfS0BPuzFbptTEHVcIKFsGF0NAcg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    dotenv "^16.3.0"
+    dotenv-expand "^10.0.0"
+    minimist "^1.2.6"
+
+dotenv-expand@10.0.0, dotenv-expand@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
   integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
@@ -3208,6 +3218,11 @@ dotenv@16.0.3:
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
   integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
+dotenv@^16.3.0:
+  version "16.4.5"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
+  integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
 
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"


### PR DESCRIPTION
Nessa tarefa, configurei um arquivo docker-compose para criar o MongoDB localmente, facilitando o desenvolvimento e testes. Também instalei o pacote dotenv-cli e ajustei o script de testes E2E para utilizar o arquivo .env.test, garantindo que o ambiente de teste esteja configurado corretamente. Além disso, adicionei os guards no questions.controller, que haviam sido esquecidos anteriormente, e configurei o setup necessário para validar se o usuário está logado nos testes E2E.